### PR TITLE
Bugfix in inference.py

### DIFF
--- a/propainter/inference.py
+++ b/propainter/inference.py
@@ -496,7 +496,7 @@ class Propainter:
                                 fps, (comp_frames[0].shape[1],comp_frames[0].shape[0]))
         for f in range(video_length):
             frame = comp_frames[f].astype(np.uint8)
-            writer.write(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+            writer.write(cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)) #Correct coversion RGB --> BGR
         writer.release()
         
         torch.cuda.empty_cache()


### PR DESCRIPTION
Fixes incorrect colors (BGR/RGB swap) in the output video generated by `Propainter.forward` in `inference.py`.

The `cv2.VideoWriter` expects BGR frames, but the frame data was being incorrectly converted using `cv2.COLOR_BGR2RGB` instead of the required `cv2.COLOR_RGB2BGR`. This change corrects the conversion, resolving the color shift issue.